### PR TITLE
message_reply.html expected a message object but it was being fed a message.text

### DIFF
--- a/ieddit.py
+++ b/ieddit.py
@@ -1022,7 +1022,7 @@ def reply_message(username=None, mid=None):
 		if hasattr(m, 'in_reply_to'):
 			if m.in_reply_to != None:
 				m.ppath = m.in_reply_to.replace(config.URL, '')
-		return render_template('message_reply.html', message=pseudo_markup(m), sendto=False)
+		return render_template('message_reply.html', message=m, sendto=False)
 
 def sendmsg(title, text, sender, sent_to):
 	cache.delete_memoized(has_messages)


### PR DESCRIPTION
Without this change every time a user replies to a message they receive a nasty 500 error straight from flask

The changes are live on the dev environment. 

Very minimal testing has been done to make sure that it works but I am confident smile