### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+static
+templates
+docker_run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+# Copy all files into /usr/src/app
+COPY . .
+
+# Replace URL in config.py with "URL = ${URL}" at line 25
+RUN sed -i "25s/.*/URL = 'http:\/\/localhost:3000'/" config.py
+
+# Replace DB_TYPE in config.py with "DB_TYPE = 'sqlite'" at line 9
+RUN sed -i "9s/.*/DB_TYPE = 'sqlite'/" config.py
+
+RUN chmod +x ./install.sh
+
+# Run install script
+RUN ./install.sh -y
+
+CMD python3 create_db.py && python3 run.py

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,7 @@
+docker run -d \
+-it \
+--name ieddit \
+-p 3000:80 \
+--mount src="$(pwd)"/static,target=/usr/src/app/static,type=bind,readonly \
+--mount src="$(pwd)"/templates,target=/usr/src/app/templates,type=bind,readonly \
+ieddit:latest


### PR DESCRIPTION
This takes care of #16 and #25 by adding basic Docker support.

As [mentioned in #16](https://github.com/cc-d/ieddit/issues/16#issuecomment-540300335), I was able to get a working Dockerfile which automatically mounts the `static` and `templates` directories as volumes, so they can be edited on the host machine while Docker is running.

A quick recap on how to use this:
1. Build a docker image with `docker build --rm -f "Dockerfile" -t ieddit:latest .`
2. Run/Create container with `./docker_run.sh`, this mounts the `static` and `templates` folder in the container, allowing the editing of their files. 
    - Note: I didn't allow ALL files to be edited because python is already running/using the server's `.py` files so editing them would require restarting the container anyways. (I think right now, you need to build again when editing the py files).
    - If there's a better way to go about this, please tell me :)
3. Access website from `http://localhost:3000`

After that you can use the typical `docker start ...` and `docker stop ...` commands, etc.